### PR TITLE
make it compatible to AbstractAuthenticationService::init

### DIFF
--- a/Classes/RsaAuthService.php
+++ b/Classes/RsaAuthService.php
@@ -80,7 +80,7 @@ class RsaAuthService extends AuthenticationService
      *
      * @return bool
      */
-    public function init()
+    public function init(): bool
     {
         return parent::init() && $this->getRsaEncryptionDecoder()->isAvailable();
     }


### PR DESCRIPTION
Fatal error: Declaration of TYPO3\CMS\Rsaauth\RsaAuthService::init() must be compatible with TYPO3\CMS\Core\Authentication\AbstractAuthenticationService::init(): bool in /home/www/jambage.com/neu/typo3conf/ext/rsaauth/Classes/RsaAuthService.php on line 83